### PR TITLE
Bypass geometry file comparison check if the geometry has been purposefully changed

### DIFF
--- a/countries/LoadNewZealand.R
+++ b/countries/LoadNewZealand.R
@@ -27,14 +27,15 @@ while(flag==0){
 
 Regions = unique(NZ$DHBName)
 DateReport = c()
+DateRecent = c()
 CaseDifference = c()
 
 for(aa in 1:length(Regions)){
 	subsetdata = NZ[which(NZ$DHBName == Regions[aa]),]
-	DateReport[aa] = as.character(max(subsetdata$ReportDate))
-	eligibleC = subsetdata$Confirmed[which(as_date(subsetdata$ReportDate)>as_date(DateReport[aa])-14)]
+	DateRecent[aa] = max(subsetdata$ReportDate)
+	eligibleC = subsetdata$Confirmed[which(as_date(subsetdata$ReportDate)>as_date(DateRecent[aa])-14)]
 	CaseDifference[aa] = (10/14)*sum(eligibleC)
-
+	DateReport[aa] = as.character(as_date(DateRecent[aa]))
 }
 
 CaseTable = data.frame(Regions,DateReport,CaseDifference)

--- a/countries/LoadSwitzerlandLiechtenstein.R
+++ b/countries/LoadSwitzerlandLiechtenstein.R
@@ -17,7 +17,7 @@ LoadSwitzerlandLiechtenstein<-function(){
 	for(aa in 1:length(code)){
 		subsetdata = CHdata[which(CHdata$geoRegion==code[aa]),]
 		LL = nrow(subsetdata)-1
-		pInf[aa] = 10/14*subsetdata$sum14d[LL]/subsetdata$pop[LL]  
+		pInf[aa] = 10/14*(subsetdata$sumTotal[LL] - subsetdata$sumTotal[LL-14])/subsetdata$pop[LL]  
 		DateReport[aa] = as.character(subsetdata$datum[LL])
 	}
 	data_join = data.frame(code,DateReport,pInf)


### PR DESCRIPTION
The updateGlobal script will now not check geometries processed by addNewGeoms() against existing similarly-named geometries. This avoids an error thrown when the new and old geometries are differently sized data frames.